### PR TITLE
Update CompletePurchasePdtResponse.php

### DIFF
--- a/src/Message/CompletePurchasePdtResponse.php
+++ b/src/Message/CompletePurchasePdtResponse.php
@@ -18,7 +18,7 @@ class CompletePurchasePdtResponse extends AbstractResponse
         $this->data = array();
 
         // parse ridiculous response format
-        $lines = explode('\n', $data);
+        $lines = explode("\n", $data);
         $this->status = $lines[0];
 
         foreach ($lines as $line) {


### PR DESCRIPTION
Single quote marks means \n is read as a string rather than a special character.
