### PR TITLE
Bug fix: CustomInt2 and notifyUrl

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -150,7 +150,7 @@ class PurchaseRequest extends AbstractRequest
         $data['merchant_key'] = $this->getMerchantKey();
         $data['return_url'] = $this->getReturnUrl();
         $data['cancel_url'] = $this->getCancelUrl();
-        $data['notify_url'] = $this->getReturnUrl();
+        $data['notify_url'] = $this->getNotifyUrl();
 
         if ($this->getCard()) {
             $data['name_first'] = $this->getCard()->getFirstName();

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -106,7 +106,7 @@ class PurchaseRequest extends AbstractRequest
         return $this->getParameter('customInt2');
     }
 
-    public function setCustomInt($value)
+    public function setCustomInt2($value)
     {
         return $this->setParameter('customInt2', $value);
     }

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -26,7 +26,7 @@ class PurchaseRequestTest extends TestCase
         );
 
         $data = $this->request->getData();
-        $this->assertSame('ab86df60906e97d3bfb362aff26fd9e6', $data['signature']);
+        $this->assertSame('812a071d77d0120073fd53ee7e45aa9b', $data['signature']);
     }
 
     public function testPurchase()


### PR DESCRIPTION
NotifyUrl was populated with returnUrl.
CustomInt2 didnt  populate due to typo in "getter" function name.

I have updated the testcase with the new signature since notify_url now not being populated.