### PR TITLE
Updated package to use omnipay v3 library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,29 @@
 language: php
 
-dist: trusty
-
 php:
-  - 5.4
-  - 5.5
   - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4snapshot
 
-before_script:
-  - composer install -n --dev --prefer-source
+# This triggers builds to run on the new TravisCI infrastructure.
+# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
 
-script: vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpunit --coverage-text
+matrix:
+  allow_failures:
+    - php: 7.4snapshot
+
+## Cache composer
+cache:
+  directories:
+    - $HOME/.composer/cache
+    
+install:
+  - composer install --prefer-dist --no-interaction
+
+script: 
+  - vendor/bin/phpcs --standard=PSR2 src
+  - vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "league/omnipay": "^3"
     },
     "require-dev": {
-        "omnipay/tests": "^3.1"
+        "omnipay/tests": "^3.1",
+        "squizlabs/php_codesniffer": "^3"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,12 @@
         "psr-4": { "Omnipay\\PayFast\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "omnipay/common": "^3.0",
+        "guzzlehttp/guzzle": "^6.3",
+        "league/omnipay": "^3"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0"
+        "omnipay/tests": "^3.1"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,9 +14,6 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="Mockery\Adapter\Phpunit\TestListener" file="vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/TestListener.php" />
-    </listeners>
     <filter>
         <whitelist>
             <directory>./src</directory>

--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -40,15 +40,13 @@ class CompletePurchaseRequest extends PurchaseRequest
         if (isset($data['pt'])) {
             // validate PDT
             $url = $this->getEndpoint().'/query/fetch';
-            $httpResponse = $this->httpClient->post($url, null, $data)->send();
-
-            return $this->response = new CompletePurchasePdtResponse($this, $httpResponse->getBody(true));
+            $httpResponse = $this->httpClient->request('post', $url, [], http_build_query($data));
+            return $this->response = new CompletePurchasePdtResponse($this, $httpResponse->getBody()->getContents());
         } else {
             // validate ITN
             $url = $this->getEndpoint().'/query/validate';
-            $httpResponse = $this->httpClient->post($url, null, $data)->send();
-            $status = $httpResponse->getBody(true);
-
+            $httpResponse = $this->httpClient->request('post', $url, [], http_build_query($data));
+            $status = $httpResponse->getBody()->getContents();
             return $this->response = new CompletePurchaseItnResponse($this, $data, $status);
         }
     }

--- a/tests/Message/CompletePurchaseRequestTest.php
+++ b/tests/Message/CompletePurchaseRequestTest.php
@@ -6,6 +6,11 @@ use Omnipay\Tests\TestCase;
 
 class CompletePurchaseRequestTest extends TestCase
 {
+    /**
+     * @var CompletePurchaseRequest
+     */
+    private $request;
+
     public function setUp()
     {
         $this->request = new CompletePurchaseRequest($this->getHttpClient(), $this->getHttpRequest());


### PR DESCRIPTION
This is a PR to make the package compatible with V3 of the Omnipay library, which is required for Symfony 3+ and associated components.