### PR TITLE
Remove guzzle version specification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     },
     "require": {
         "omnipay/common": "^3.0",
-        "guzzlehttp/guzzle": "^6.3",
         "league/omnipay": "^3"
     },
     "require-dev": {


### PR DESCRIPTION
Removed guzzle version, let it inherit from omnipay core.
Previous setting of guzzlehttp/guzzle ^6.3 was incompatible with latest omnipay which uses guzzle7.